### PR TITLE
 Pass options to script(), css() and scriptBlock() methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,22 @@ The Froala helper is basically just a convenience helper that allows you to use 
 ```php
 // Loads Froala Editor javascript also will load all the plugins and css for the plugins
 <?= $this->Froala->plugin();?>
+// You can provide common options for CakePHP HtmlHelper script() and css() methods in first parameter
+// Or specific options for script() (2nd argument) or css() (3rd argument)
+<?= $this->Froala->plugin(array('block' => 'bottom'), array('specificJsOpton' => 'someValue'), array('specificCssOpton' => 'someValue') );?>
 
 // Will target one specific html selector on which the editor will be init.
-// Second paramenter is mix can be array/object of options that the Froala Editor will take.
+// Second paramenter is mix can be array/object of options that the Froala Editor will take
+// Third parameter is array of options for CakePHP HtmlHelper::scriptBlock() method
+<?= $this->Froala->editor('#froala', array('option' => value), array('block' => 'bottom') );?>
 
-<?= $this->Froala->editor('#froala', array('option' => value));?>
+// Third parameter can be false to return script line without <script></script> block
+// So you can output in in your custom script block
+<script>
+    window.onload = function(){
+		<?= $this->Froala->editor('#froala', array('option' => value), false);?>
+	};
+</script>
 ```
 
 If your app is not set up to work in the top level of your host / but instead in /yourapp/ the automatic inclusion of the script wont work. You'll manually have to add the js file to your app inisde the helper class. 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ Alternatively, you can download an archive from the [master branch on Github](ht
 
 Make sure that you load the plugin routes by adding to your bootstrap file: 
 
-Plugin::loadAll(); or  Plugin::load('Froala');
+`Plugin::loadAll();` or  `Plugin::load('Froala');`
 This will load all plugins at once or only the Froala plugin.
 
+This can be done automatically bu Cake
+
+    bin/cake plugin load Froala
 
 ## Usage
 The Froala helper is basically just a convenience helper that allows you to use php and CakePHP conventions to generate the configuration for Froala and as an extra it allows you to load configs.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ Or if your CakePHP application is setup as a git repository, you can add it as a
 
 	git submodule add git://github.com/froala/wysiwyg-cake.git Plugin/Froala
 
+Or using Composer:
+
+    php ./composer.phar require froala/wysiwyg-cake
+
 Alternatively, you can download an archive from the [master branch on Github](https://github.com/froala/wysiwyg-cake/archive/master.zip) and extract the contents to `Froala plugin`.
 
 Make sure that you load the plugin routes by adding to your bootstrap file: 

--- a/src/Controller/FroalaController.php
+++ b/src/Controller/FroalaController.php
@@ -1,9 +1,9 @@
 <?php
-namespace App\Controller;
+namespace Froala\Controller;
 
-use App\Controller\AppController;
+use Cake\Controller\Controller;
 
-class FroalaController extends AppController
+class FroalaController extends Controller
 {
 
 }

--- a/src/View/Helper/FroalaHelper.php
+++ b/src/View/Helper/FroalaHelper.php
@@ -25,10 +25,12 @@ class FroalaHelper extends Helper
 	 * Adds a new editor to the script block on the page
 	 *
 	 * @see http://editor.froala.com/docs/options for a list of keys
-	 * @param mixed
+	 * @param mixed $selector
+	 * @param mixed $options
+	 * @param mixed $scriptBlockOptions Options array for HtmlHelper::scriptBlock() of false for return without block at all
 	 * @return void
 	 */
-	public function editor($selector = null, $options = null) {
+	public function editor($selector = null, $options = null, $scriptBlockOptions = []) {
 
 		$configs = Configure::read('Froala.editorOptions');
 		if (!empty($configs) && is_array($configs)) {
@@ -44,17 +46,22 @@ class FroalaHelper extends Helper
 		else {
 			$options = '{}';
 		}
-
-		echo $this->Html->scriptBlock('$(function() {$("' . $selector . '").froalaEditor(' . "\n" . $options . "\n" . ');})' . "\n");
+        $script_str = '$(function() {$("' . $selector . '").froalaEditor(' . "\n" . $options . "\n" . ');})' . "\n";
+        
+        echo is_array($scriptBlockOptions) ? $this->Html->scriptBlock($script_str, $scriptBlockOptions) : $script_str;
 	}
 
 
 	/**
 	 * Loads up all the plugins and css for plugins upon calling.
+	 * @param   array   $common_options Common options for HtmlHelper script() and css() methods
+	 * @param   array   $js_options     Specific options for HtmlHelper::script() method
+	 * @param   array   $css_options    Specific options for HtmlHelper::css() method
 	 *
 	 */
-	public function plugin() {
-
+	public function plugin($common_options = array(), $js_options = array(), $css_options = array()) {
+        $js_options = array_merge(array('toolbarInline' => false), $common_options, $js_options);
+        $css_options = array_merge(array('toolbarInline' => false), $common_options, $css_options);
 		echo $this->Html->script(array(
 			'/Froala/js/froala_editor.min.js',
 			'/Froala/js/plugins/align.min.js',
@@ -90,7 +97,7 @@ class FroalaHelper extends Helper
 			'/Froala/js/plugins/url.min.js',
 			'/Froala/js/plugins/video.min.js',
 			'/Froala/js/plugins/word_paste.min.js'
-			), array('toolbarInline' => false));
+			), $js_options);
 		echo $this->Html->css(array(
 				'/Froala/css/froala_editor.min.css',
 				'/Froala/css/froala_style.min.css',
@@ -112,7 +119,7 @@ class FroalaHelper extends Helper
 				'/Froala/css/plugins/table.min.css',
 				'/Froala/css/plugins/video.min.css',
 				'https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css'
-			)
+			), $css_options
 		);
 	}
 


### PR DESCRIPTION
Ability to load Froala scripts and styles in block if you want to load them on bottom of the page for #5 

Also ability to output `.froalaEditor()`  binding in block either or without block at all in case you need to load editor by event e.g.

```
<script>
    window.onload = function(){
		<?= $this->Froala->editor('#froala', array('option' => value), false);?>
	};
</script>
```

All changes reflected in the REDAME.md

Additionally i have add in README installing using Composer method and how to enable plugin using cake console